### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The main `css` file is located in the `dist/` folder. Include it on every `HTML`
 Or you can use the hosted version on [jsDelivr](https://www.jsdelivr.com/projects/siimple):
 
 ```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/siimple/VERSION/siimple.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/siimple@VERSION/dist/siimple.min.css">
 ```
 
 Guides and reference are published in [siimple.juanes.xyz/docs](http://siimple.juanes.xyz/docs). Take a look and start creating your web page!


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.
I also noticed an old link at https://siimple.juanes.xyz/docs, the correct link is https://cdn.jsdelivr.net/npm/siimple@VERSION/dist/siimple.min.css

You can find links for all files at https://www.jsdelivr.com/package/npm/siimple.

Feel free to ping me if you have any questions regarding this change.