### PR TITLE
Add 'siimple-table-cell--{size}'.

### DIFF
--- a/docs/_posts/2017-05-06-table.html
+++ b/docs/_posts/2017-05-06-table.html
@@ -185,5 +185,55 @@ keywords: "table,tables,row,rows,columns,cells,header,body"
 &lt;/div&gt;
 </pre>
 
+<div class="siimple-h5">Sizing columns</div>
+<div class="siimple-p">
+    To organize table with 12 columns, add <code class="siimple-code">siimple-table-cell--{size}</code>.
+</div>
+<div class="sd-snippet-demo">
+    <div class="siimple-table" style="margin-bottom:0px !important;">
+        <div class="siimple-table-header">
+            <div class="siimple-table-row">
+                <div class="siimple-table-cell siimple-table-cell--2">Header 1</div>
+                <div class="siimple-table-cell siimple-table-cell--5">Header 2</div>
+                <div class="siimple-table-cell siimple-table-cell--5">Header 3</div>
+            </div>
+        </div>
+        <div class="siimple-table-body">
+            <div class="siimple-table-row">
+                <div class="siimple-table-cell">Cell 1</div>
+                <div class="siimple-table-cell">Cell 2</div>
+                <div class="siimple-table-cell">Cell 3</div>
+            </div>
+            <div class="siimple-table-row">
+                <div class="siimple-table-cell">Cell 4</div>
+                <div class="siimple-table-cell">Cell 5</div>
+                <div class="siimple-table-cell">Cell 6</div>
+            </div>
+        </div>
+    </div>
+</div>
+<pre class="sd-snippet-code">
+&lt;div class="siimple-table"&gt;
+    &lt;div class="siimple-table-header"&gt;
+        &lt;div class="siimple-table-row"&gt;
+            &lt;div class="siimple-table-cell siimple-table-cell--2"&gt;Header 1&lt;/div&gt;
+            &lt;div class="siimple-table-cell siimple-table-cell--5"&gt;Header 2&lt;/div&gt;
+            &lt;div class="siimple-table-cell siimple-table-cell--5"&gt;Header 3&lt;/div&gt;
+        &lt;/div&gt;
+    &lt;/div&gt;
+    &lt;div class="siimple-table-body"&gt;
+        &lt;div class="siimple-table-row"&gt;
+            &lt;div class="siimple-table-cell"&gt;Cell 1&lt;/div&gt;
+            &lt;div class="siimple-table-cell"&gt;Cell 2&lt;/div&gt;
+            &lt;div class="siimple-table-cell"&gt;Cell 3&lt;/div&gt;
+        &lt;/div&gt;
+        &lt;div class="siimple-table-row"&gt;
+            &lt;div class="siimple-table-cell"&gt;Cell 1&lt;/div&gt;
+            &lt;div class="siimple-table-cell"&gt;Cell 2&lt;/div&gt;
+            &lt;div class="siimple-table-cell"&gt;Cell 3&lt;/div&gt;
+        &lt;/div&gt;
+    &lt;/div&gt;
+&lt;/div&gt;
+</pre>
 
 

--- a/scss/components/_table.scss
+++ b/scss/components/_table.scss
@@ -12,6 +12,9 @@
 $siimple-table-width: 100%;
 $siimple-table-cell-padding: 10px;
 
+//Table cell variables
+$siimple-table-cell-sizes: $siimple-default-grid;
+
 //Table class
 .siimple-table {
     display: table;
@@ -43,6 +46,12 @@ $siimple-table-cell-padding: 10px;
         white-space: nowrap;
         overflow: hidden;
         transition: background-color 0.3s;
+    }
+    //Table cell sizes
+    @each $cell-name, $cell-width in $siimple-table-cell-sizes {
+        &-cell--#{$cell-name} {
+            width: #{$cell-width};
+        }
     }
     //Table with border
     &--border &-cell:not(:last-child) {


### PR DESCRIPTION
I added new feature #50 .

##### Notice::
If the column contains long texts, we also need to specify `white-space:normal;` or `overflow:visible;` on table cells for sizing completely. Since this notice is not limited to sizing cell, I have not written it in the document.

Thanks.